### PR TITLE
Add CI for wasm

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,15 @@
+name: wasm
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - run: cargo test
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --firefox


### PR DESCRIPTION
The code is taken from the example for CI of wasm-bindgen-test https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/continuous-integration.html